### PR TITLE
Fix crash where SubscriptionHelper.deferredRequest with non-positive values.

### DIFF
--- a/src/main/java/hu/akarnokd/rxjava/interop/FlowableV2ToObservableV1.java
+++ b/src/main/java/hu/akarnokd/rxjava/interop/FlowableV2ToObservableV1.java
@@ -57,7 +57,9 @@ final class FlowableV2ToObservableV1<T> implements rx.Observable.OnSubscribe<T> 
 
         @Override
         public void request(long n) {
-            io.reactivex.internal.subscriptions.SubscriptionHelper.deferredRequest(this, requested, n);
+            if (n > 0) {
+                io.reactivex.internal.subscriptions.SubscriptionHelper.deferredRequest(this, requested, n);
+            }
         }
 
         @Override


### PR DESCRIPTION
This is an attempt to fix for https://github.com/akarnokd/RxJava2Interop/issues/10.

Some operators (filter in particular) will request zero items, but this does not work with RxJava2.

I'm not sure if this is the correct fix or if there are any implications of this - I'm mostly opening this up to start a discussion.