### PR TITLE
Observable.Transformer -> ObservableTransformer

### DIFF
--- a/src/main/java/hu/akarnokd/rxjava/interop/RxJavaInterop.java
+++ b/src/main/java/hu/akarnokd/rxjava/interop/RxJavaInterop.java
@@ -16,6 +16,8 @@
 
 package hu.akarnokd.rxjava.interop;
 
+import io.reactivex.BackpressureStrategy;
+
 /**
  * Conversion methods for converting between 1.x and 2.x reactive types, composing backpressure
  * and cancellation through.
@@ -498,6 +500,30 @@ public final class RxJavaInterop {
             @Override
             public rx.Observable<R> call(rx.Observable<T> f) {
                 return toV1Observable(transformer.apply(toV2Flowable(f)));
+            }
+        };
+    }
+
+    /**
+     * Convert the 2.x ObservableTransformer into a 1.x Observable.Transformer.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>The method does not operate by default on a particular {@code Scheduler}.</dd>
+     * </dl>
+     * @param <T> the input value type
+     * @param <R> the output value type
+     * @param transformer the 2.x ObservableTransformer to convert
+     * @param strategy the backpressure strategy to apply: BUFFER, DROP or LATEST.
+     * @return the new Observable.Transformer instance
+     */
+    @io.reactivex.annotations.SchedulerSupport(io.reactivex.annotations.SchedulerSupport.NONE)
+    public static <T, R> rx.Observable.Transformer<T, R> toV1Transformer(final io.reactivex.ObservableTransformer<T, R> transformer,
+        final BackpressureStrategy strategy) {
+        io.reactivex.internal.functions.ObjectHelper.requireNonNull(transformer, "transformer is null");
+        return new rx.Observable.Transformer<T, R>() {
+            @Override
+            public rx.Observable<R> call(rx.Observable<T> obs) {
+                return toV1Observable(transformer.apply(toV2Observable(obs)), strategy);
             }
         };
     }

--- a/src/main/java/hu/akarnokd/rxjava/interop/RxJavaInterop.java
+++ b/src/main/java/hu/akarnokd/rxjava/interop/RxJavaInterop.java
@@ -16,9 +16,6 @@
 
 package hu.akarnokd.rxjava.interop;
 
-import io.reactivex.BackpressureStrategy;
-import io.reactivex.ObservableSource;
-
 /**
  * Conversion methods for converting between 1.x and 2.x reactive types, composing backpressure
  * and cancellation through.
@@ -222,14 +219,15 @@ public final class RxJavaInterop {
      * @param strategy the backpressure strategy to apply: BUFFER, DROP or LATEST.
      * @param transformer the 1.x Observable.Transformer to convert
      * @return the new ObservableTransformer instance
+     * @since 0.12.0
      */
     @io.reactivex.annotations.SchedulerSupport(io.reactivex.annotations.SchedulerSupport.NONE)
     public static <T, R> io.reactivex.ObservableTransformer<T, R> toV2Transformer(final rx.Observable.Transformer<T, R> transformer,
-        final BackpressureStrategy strategy) {
+        final io.reactivex.BackpressureStrategy strategy) {
         io.reactivex.internal.functions.ObjectHelper.requireNonNull(transformer, "transformer is null");
         return new io.reactivex.ObservableTransformer<T, R>() {
             @Override
-            public ObservableSource<R> apply(io.reactivex.Observable<T> obs) {
+            public io.reactivex.ObservableSource<R> apply(io.reactivex.Observable<T> obs) {
                 return toV2Observable(transformer.call(toV1Observable(obs, strategy)));
             }
         };
@@ -540,10 +538,11 @@ public final class RxJavaInterop {
      * @param transformer the 2.x ObservableTransformer to convert
      * @param strategy the backpressure strategy to apply: BUFFER, DROP or LATEST.
      * @return the new Observable.Transformer instance
+     * @since 0.12.0
      */
     @io.reactivex.annotations.SchedulerSupport(io.reactivex.annotations.SchedulerSupport.NONE)
     public static <T, R> rx.Observable.Transformer<T, R> toV1Transformer(final io.reactivex.ObservableTransformer<T, R> transformer,
-        final BackpressureStrategy strategy) {
+        final io.reactivex.BackpressureStrategy strategy) {
         io.reactivex.internal.functions.ObjectHelper.requireNonNull(transformer, "transformer is null");
         return new rx.Observable.Transformer<T, R>() {
             @Override

--- a/src/main/java/hu/akarnokd/rxjava/interop/RxJavaInterop.java
+++ b/src/main/java/hu/akarnokd/rxjava/interop/RxJavaInterop.java
@@ -17,6 +17,7 @@
 package hu.akarnokd.rxjava.interop;
 
 import io.reactivex.BackpressureStrategy;
+import io.reactivex.ObservableSource;
 
 /**
  * Conversion methods for converting between 1.x and 2.x reactive types, composing backpressure
@@ -206,6 +207,30 @@ public final class RxJavaInterop {
             @Override
             public org.reactivestreams.Publisher<R> apply(io.reactivex.Flowable<T> f) {
                 return toV2Flowable(transformer.call(toV1Observable(f)));
+            }
+        };
+    }
+
+    /**
+     * Convert the 1.x Observable.Transformer into a 2.x ObservableTransformer.
+     * <dl>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>The method does not operate by default on a particular {@code Scheduler}.</dd>
+     * </dl>
+     * @param <T> the input value type
+     * @param <R> the output value type
+     * @param strategy the backpressure strategy to apply: BUFFER, DROP or LATEST.
+     * @param transformer the 1.x Observable.Transformer to convert
+     * @return the new ObservableTransformer instance
+     */
+    @io.reactivex.annotations.SchedulerSupport(io.reactivex.annotations.SchedulerSupport.NONE)
+    public static <T, R> io.reactivex.ObservableTransformer<T, R> toV2Transformer(final rx.Observable.Transformer<T, R> transformer,
+        final BackpressureStrategy strategy) {
+        io.reactivex.internal.functions.ObjectHelper.requireNonNull(transformer, "transformer is null");
+        return new io.reactivex.ObservableTransformer<T, R>() {
+            @Override
+            public ObservableSource<R> apply(io.reactivex.Observable<T> obs) {
+                return toV2Observable(transformer.call(toV1Observable(obs, strategy)));
             }
         };
     }

--- a/src/test/java/hu/akarnokd/rxjava/interop/RxJavaInteropTest.java
+++ b/src/test/java/hu/akarnokd/rxjava/interop/RxJavaInteropTest.java
@@ -1323,6 +1323,26 @@ public class RxJavaInteropTest {
     }
 
     @Test
+    public void ot2ToOt1() {
+        ObservableTransformer<Integer, Integer> transformer = new ObservableTransformer<Integer, Integer>() {
+            @Override
+            public io.reactivex.Observable<Integer> apply(io.reactivex.Observable<Integer> o) {
+                return o.map(new Function<Integer, Integer>() {
+                    @Override
+                    public Integer apply(Integer v) {
+                        return v + 1;
+                    }
+                });
+            }
+        };
+
+        rx.Observable.just(1)
+            .compose(toV1Transformer(transformer, BackpressureStrategy.BUFFER))
+            .test()
+            .assertResult(2);
+    }
+
+    @Test
     public void st1ToSt2() {
         rx.Single.Transformer<Integer, Integer> transformer = new rx.Single.Transformer<Integer, Integer>() {
             @Override

--- a/src/test/java/hu/akarnokd/rxjava/interop/RxJavaInteropTest.java
+++ b/src/test/java/hu/akarnokd/rxjava/interop/RxJavaInteropTest.java
@@ -1322,6 +1322,26 @@ public class RxJavaInteropTest {
         .assertResult(2);
     }
 
+  @Test
+  public void ot1ToOt2() {
+    rx.Observable.Transformer<Integer, Integer> transformer = new rx.Observable.Transformer<Integer, Integer>() {
+      @Override
+      public Observable<Integer> call(Observable<Integer> o) {
+        return o.map(new Func1<Integer, Integer>() {
+          @Override
+          public Integer call(Integer v) {
+            return v + 1;
+          }
+        });
+      }
+    };
+
+    io.reactivex.Observable.just(1)
+        .compose(toV2Transformer(transformer, BackpressureStrategy.BUFFER))
+        .test()
+        .assertResult(2);
+  }
+
     @Test
     public void ot2ToOt1() {
         ObservableTransformer<Integer, Integer> transformer = new ObservableTransformer<Integer, Integer>() {


### PR DESCRIPTION
Added some helpers for converting between Observable.Transformer and ObservableTransformer.  Handles backpressure by taking a strategy as input, similar to helpers for FlowableTransformer.