### PR TITLE
Add 2.x Scheduler to 1.x Scheduler conversion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,11 @@ io.reactivex.disposables.Disposable d2 = RxJavaInterop.toV2Disposable(rx.Subscri
 
 rx.Subscription s1 = RxJavaInterop.toV1Subscription(io.reactivex.disposables.Disposable);
 ```
+
+### Convert between 2.x `Scheduler` and 1.x `Scheduler`
+
+```java
+// convert from 2.x to 1.x
+
+rx.Scheduler s1 = RxJavaInterop.toV1Scheduler(io.reactivex.Scheduler);
+```

--- a/src/main/java/hu/akarnokd/rxjava/interop/RxJavaInterop.java
+++ b/src/main/java/hu/akarnokd/rxjava/interop/RxJavaInterop.java
@@ -16,6 +16,8 @@
 
 package hu.akarnokd.rxjava.interop;
 
+import io.reactivex.Scheduler;
+
 /**
  * Conversion methods for converting between 1.x and 2.x reactive types, composing backpressure
  * and cancellation through.
@@ -655,4 +657,14 @@ public final class RxJavaInterop {
         return new DisposableV2ToSubscriptionV1(disposable);
     }
 
+    /**
+     * Convert the 2.x {@link io.reactivex.Scheduler} into a 1.x {@link rx.Scheduler}.
+     * @param scheduler the 2.x Scheduler to convert
+     * @return the new 1.x Scheduler instance
+     * @since 0.12.0
+     */
+    public static rx.Scheduler toV1Scheduler(Scheduler scheduler) {
+        io.reactivex.internal.functions.ObjectHelper.requireNonNull(scheduler, "scheduler is null");
+        return new SchedulerV2ToSchedulerV1(scheduler);
+    }
 }

--- a/src/main/java/hu/akarnokd/rxjava/interop/SchedulerV2ToSchedulerV1.java
+++ b/src/main/java/hu/akarnokd/rxjava/interop/SchedulerV2ToSchedulerV1.java
@@ -1,6 +1,5 @@
 package hu.akarnokd.rxjava.interop;
 
-
 import io.reactivex.Scheduler;
 import rx.Subscription;
 import rx.functions.Action0;
@@ -24,48 +23,54 @@ final class SchedulerV2ToSchedulerV1 extends rx.Scheduler {
 
     @Override
     public Worker createWorker() {
-        final Scheduler.Worker v2Worker = source.createWorker();
+        return new WorkerV2ToWorkerV1(source.createWorker());
+    }
 
-        return new Worker() {
-            @Override
-            public Subscription schedule(Action0 action) {
-                return RxJavaInterop.toV1Subscription(v2Worker.schedule(new Action0V1ToRunnable(action)));
-            }
+    static final class WorkerV2ToWorkerV1 extends Worker {
 
-            @Override
-            public Subscription schedule(Action0 action, long delayTime, TimeUnit unit) {
-                return RxJavaInterop.toV1Subscription(
-                        v2Worker.schedule(new Action0V1ToRunnable(action), delayTime, unit)
-                );
-            }
+        final Scheduler.Worker v2Worker;
 
-            @Override
-            public Subscription schedulePeriodically(Action0 action, long initialDelay, long period, TimeUnit unit) {
-                return RxJavaInterop.toV1Subscription(v2Worker.schedulePeriodically(
-                        new Action0V1ToRunnable(action), initialDelay, period, unit)
-                );
-            }
+        WorkerV2ToWorkerV1(Scheduler.Worker v2Worker) {
+            this.v2Worker = v2Worker;
+        }
 
-            @Override
-            public long now() {
-                return v2Worker.now(MILLISECONDS);
-            }
+        @Override
+        public Subscription schedule(Action0 action) {
+            final Action0V1ToRunnable runnable = new Action0V1ToRunnable(action);
+            return RxJavaInterop.toV1Subscription(v2Worker.schedule(runnable));
+        }
 
-            @Override
-            public void unsubscribe() {
-                v2Worker.dispose();
-            }
+        @Override
+        public Subscription schedule(Action0 action, long delayTime, TimeUnit unit) {
+            final Action0V1ToRunnable runnable = new Action0V1ToRunnable(action);
+            return RxJavaInterop.toV1Subscription(v2Worker.schedule(runnable, delayTime, unit));
+        }
 
-            @Override
-            public boolean isUnsubscribed() {
-                return v2Worker.isDisposed();
-            }
-        };
+        @Override
+        public Subscription schedulePeriodically(Action0 action, long initialDelay, long period, TimeUnit unit) {
+            final Action0V1ToRunnable runnable = new Action0V1ToRunnable(action);
+            return RxJavaInterop.toV1Subscription(v2Worker.schedulePeriodically(runnable, initialDelay, period, unit));
+        }
+
+        @Override
+        public long now() {
+            return v2Worker.now(MILLISECONDS);
+        }
+
+        @Override
+        public void unsubscribe() {
+            v2Worker.dispose();
+        }
+
+        @Override
+        public boolean isUnsubscribed() {
+            return v2Worker.isDisposed();
+        }
     }
 
     static final class Action0V1ToRunnable implements Runnable {
 
-        private final Action0 source;
+        final Action0 source;
 
         Action0V1ToRunnable(Action0 source) {
             io.reactivex.internal.functions.ObjectHelper.requireNonNull(source, "Source 1.x Action0 is null");

--- a/src/main/java/hu/akarnokd/rxjava/interop/SchedulerV2ToSchedulerV1.java
+++ b/src/main/java/hu/akarnokd/rxjava/interop/SchedulerV2ToSchedulerV1.java
@@ -1,0 +1,83 @@
+package hu.akarnokd.rxjava.interop;
+
+
+import io.reactivex.Scheduler;
+import rx.Subscription;
+import rx.functions.Action0;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+final class SchedulerV2ToSchedulerV1 extends rx.Scheduler {
+
+    private final Scheduler source;
+
+    SchedulerV2ToSchedulerV1(Scheduler source) {
+        this.source = source;
+    }
+
+    @Override
+    public long now() {
+        return source.now(MILLISECONDS);
+    }
+
+    @Override
+    public Worker createWorker() {
+        final Scheduler.Worker v2Worker = source.createWorker();
+
+        return new Worker() {
+            @Override
+            public Subscription schedule(Action0 action) {
+                return RxJavaInterop.toV1Subscription(v2Worker.schedule(new Action0V1ToRunnable(action)));
+            }
+
+            @Override
+            public Subscription schedule(Action0 action, long delayTime, TimeUnit unit) {
+                return RxJavaInterop.toV1Subscription(
+                        v2Worker.schedule(new Action0V1ToRunnable(action), delayTime, unit)
+                );
+            }
+
+            @Override
+            public Subscription schedulePeriodically(Action0 action, long initialDelay, long period, TimeUnit unit) {
+                return RxJavaInterop.toV1Subscription(v2Worker.schedulePeriodically(
+                        new Action0V1ToRunnable(action), initialDelay, period, unit)
+                );
+            }
+
+            @Override
+            public long now() {
+                return v2Worker.now(MILLISECONDS);
+            }
+
+            @Override
+            public void unsubscribe() {
+                v2Worker.dispose();
+            }
+
+            @Override
+            public boolean isUnsubscribed() {
+                return v2Worker.isDisposed();
+            }
+        };
+    }
+
+    static final class Action0V1ToRunnable implements Runnable {
+
+        private final Action0 source;
+
+        Action0V1ToRunnable(Action0 source) {
+            if (source == null) {
+                io.reactivex.internal.functions.ObjectHelper.requireNonNull(source, "Source 1.x Action0 is null");
+            }
+
+            this.source = source;
+        }
+
+        @Override
+        public void run() {
+            source.call();
+        }
+    }
+}

--- a/src/main/java/hu/akarnokd/rxjava/interop/SchedulerV2ToSchedulerV1.java
+++ b/src/main/java/hu/akarnokd/rxjava/interop/SchedulerV2ToSchedulerV1.java
@@ -68,10 +68,7 @@ final class SchedulerV2ToSchedulerV1 extends rx.Scheduler {
         private final Action0 source;
 
         Action0V1ToRunnable(Action0 source) {
-            if (source == null) {
-                io.reactivex.internal.functions.ObjectHelper.requireNonNull(source, "Source 1.x Action0 is null");
-            }
-
+            io.reactivex.internal.functions.ObjectHelper.requireNonNull(source, "Source 1.x Action0 is null");
             this.source = source;
         }
 

--- a/src/test/java/hu/akarnokd/rxjava/interop/RxJavaInteropV2SchedulerToV1SchedulerTest.java
+++ b/src/test/java/hu/akarnokd/rxjava/interop/RxJavaInteropV2SchedulerToV1SchedulerTest.java
@@ -7,8 +7,7 @@ import rx.functions.Action0;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class RxJavaInteropV2SchedulerToV1SchedulerTest {
@@ -66,7 +65,7 @@ public class RxJavaInteropV2SchedulerToV1SchedulerTest {
         v2Scheduler.advanceTimeBy(1L, MINUTES);
         verify(action0).call();
 
-        v2Scheduler.advanceTimeBy(125, MINUTES); // Check that it's not periodic.
+        v2Scheduler.advanceTimeBy(125L, MINUTES); // Check that it's not periodic.
         verifyNoMoreInteractions(action0);
     }
 
@@ -148,7 +147,7 @@ public class RxJavaInteropV2SchedulerToV1SchedulerTest {
         when(v2Scheduler.createWorker()).thenReturn(v2Worker);
 
         rx.Scheduler.Worker v1Worker = v1Scheduler.createWorker();
-        verify(v2Worker, times(0)).dispose();
+        verify(v2Worker, never()).dispose();
 
         v1Worker.unsubscribe();
         verify(v2Worker).dispose();
@@ -165,9 +164,9 @@ public class RxJavaInteropV2SchedulerToV1SchedulerTest {
         rx.Scheduler.Worker v1Worker = v1Scheduler.createWorker();
 
         when(v2Worker.isDisposed()).thenReturn(true);
-        assertEquals(true, v1Worker.isUnsubscribed());
+        assertTrue(v1Worker.isUnsubscribed());
 
         when(v2Worker.isDisposed()).thenReturn(false);
-        assertEquals(false, v1Worker.isUnsubscribed());
+        assertFalse(v1Worker.isUnsubscribed());
     }
 }

--- a/src/test/java/hu/akarnokd/rxjava/interop/RxJavaInteropV2SchedulerToV1SchedulerTest.java
+++ b/src/test/java/hu/akarnokd/rxjava/interop/RxJavaInteropV2SchedulerToV1SchedulerTest.java
@@ -1,0 +1,173 @@
+package hu.akarnokd.rxjava.interop;
+
+import io.reactivex.Scheduler;
+import io.reactivex.schedulers.TestScheduler;
+import org.junit.Test;
+import rx.functions.Action0;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.*;
+
+public class RxJavaInteropV2SchedulerToV1SchedulerTest {
+
+    @Test
+    public void now() {
+        Scheduler v2Scheduler = mock(Scheduler.class);
+        rx.Scheduler v1Scheduler = RxJavaInterop.toV1Scheduler(v2Scheduler);
+
+        when(v2Scheduler.now(MILLISECONDS)).thenReturn(123L);
+
+        assertEquals(123L, v1Scheduler.now());
+    }
+
+    @Test
+    public void workerSchedule() {
+        TestScheduler v2Scheduler = new TestScheduler();
+        rx.Scheduler v1Scheduler = RxJavaInterop.toV1Scheduler(v2Scheduler);
+
+        Action0 action0 = mock(Action0.class);
+
+        v1Scheduler.createWorker().schedule(action0);
+        verifyZeroInteractions(action0);
+
+        v2Scheduler.triggerActions();
+        verify(action0).call();
+    }
+
+    @Test
+    public void workerScheduleNullAction() {
+        Scheduler v2Scheduler = mock(Scheduler.class);
+        rx.Scheduler v1Scheduler = RxJavaInterop.toV1Scheduler(v2Scheduler);
+
+        try {
+            v1Scheduler.createWorker().schedule(null);
+            fail();
+        } catch (NullPointerException expected) {
+            assertEquals("Source 1.x Action0 is null", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void workerScheduleDelayed() {
+        TestScheduler v2Scheduler = new TestScheduler();
+        rx.Scheduler v1Scheduler = RxJavaInterop.toV1Scheduler(v2Scheduler);
+
+        Action0 action0 = mock(Action0.class);
+
+        v1Scheduler.createWorker().schedule(action0, 123L, MINUTES);
+        verifyZeroInteractions(action0);
+
+        v2Scheduler.advanceTimeBy(122L, MINUTES);
+        verifyZeroInteractions(action0);
+
+        v2Scheduler.advanceTimeBy(1L, MINUTES);
+        verify(action0).call();
+
+        v2Scheduler.advanceTimeBy(125, MINUTES); // Check that it's not periodic.
+        verifyNoMoreInteractions(action0);
+    }
+
+    @Test
+    public void workerScheduleDelayedNullAction() {
+        Scheduler v2Scheduler = mock(Scheduler.class);
+        rx.Scheduler v1Scheduler = RxJavaInterop.toV1Scheduler(v2Scheduler);
+
+        try {
+            v1Scheduler.createWorker().schedule(null, 123L, MINUTES);
+            fail();
+        } catch (NullPointerException expected) {
+            assertEquals("Source 1.x Action0 is null", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void workerSchedulePeriodically() {
+        TestScheduler v2Scheduler = new TestScheduler();
+        rx.Scheduler v1Scheduler = RxJavaInterop.toV1Scheduler(v2Scheduler);
+
+        Action0 action0 = mock(Action0.class);
+
+        v1Scheduler.createWorker().schedulePeriodically(action0, 10L, 123L, MINUTES);
+        verifyZeroInteractions(action0);
+
+        v2Scheduler.advanceTimeBy(9L, MINUTES);
+        verifyZeroInteractions(action0);
+
+        v2Scheduler.advanceTimeBy(1L, MINUTES);
+        verify(action0).call();
+
+        v2Scheduler.advanceTimeBy(122L, MINUTES);
+        verifyNoMoreInteractions(action0);
+
+        v2Scheduler.advanceTimeBy(1L, MINUTES);
+        verify(action0, times(2)).call();
+
+        v2Scheduler.advanceTimeBy(123L, MINUTES);
+        verify(action0, times(3)).call(); // Verify periodic.
+
+        v2Scheduler.advanceTimeBy(123L, MINUTES);
+        verify(action0, times(4)).call(); // Verify periodic.
+    }
+
+    @Test
+    public void workerSchedulePeriodicallyNullAction() {
+        Scheduler v2Scheduler = mock(Scheduler.class);
+        rx.Scheduler v1Scheduler = RxJavaInterop.toV1Scheduler(v2Scheduler);
+
+        try {
+            v1Scheduler.createWorker().schedulePeriodically(null, 10L, 123L, MINUTES);
+            fail();
+        } catch (NullPointerException expected) {
+            assertEquals("Source 1.x Action0 is null", expected.getMessage());
+        }
+    }
+
+    @Test
+    public void workerNow() {
+        Scheduler v2Scheduler = mock(Scheduler.class);
+        rx.Scheduler v1Scheduler = RxJavaInterop.toV1Scheduler(v2Scheduler);
+
+        Scheduler.Worker v2Worker = mock(Scheduler.Worker.class);
+        when(v2Scheduler.createWorker()).thenReturn(v2Worker);
+        rx.Scheduler.Worker v1Worker = v1Scheduler.createWorker();
+
+        when(v2Worker.now(MILLISECONDS)).thenReturn(123L);
+
+        assertEquals(123L, v1Worker.now());
+    }
+
+    @Test
+    public void workerUnsubscribe() {
+        Scheduler v2Scheduler = mock(Scheduler.class);
+        rx.Scheduler v1Scheduler = RxJavaInterop.toV1Scheduler(v2Scheduler);
+
+        Scheduler.Worker v2Worker = mock(Scheduler.Worker.class);
+        when(v2Scheduler.createWorker()).thenReturn(v2Worker);
+
+        rx.Scheduler.Worker v1Worker = v1Scheduler.createWorker();
+        verify(v2Worker, times(0)).dispose();
+
+        v1Worker.unsubscribe();
+        verify(v2Worker).dispose();
+    }
+
+    @Test
+    public void workerIsUnsubscribed() {
+        Scheduler v2Scheduler = mock(Scheduler.class);
+        rx.Scheduler v1Scheduler = RxJavaInterop.toV1Scheduler(v2Scheduler);
+
+        Scheduler.Worker v2Worker = mock(Scheduler.Worker.class);
+        when(v2Scheduler.createWorker()).thenReturn(v2Worker);
+
+        rx.Scheduler.Worker v1Worker = v1Scheduler.createWorker();
+
+        when(v2Worker.isDisposed()).thenReturn(true);
+        assertEquals(true, v1Worker.isUnsubscribed());
+
+        when(v2Worker.isDisposed()).thenReturn(false);
+        assertEquals(false, v1Worker.isUnsubscribed());
+    }
+}


### PR DESCRIPTION
Noticed a bug in our internal impl and decided to rewrite it and push to upstream.

@akarnokd do you think I should add v1 to v2 Scheduler conversion? We only need v2 to v1 since we're  aggressively replacing v1 with v2 and not vice versa.